### PR TITLE
fix: React not defined error when using aio-cli-plugin-app@7.x (parcel-2)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "plugins": ["@babel/plugin-transform-react-jsx"],
   "presets": [
     [
       "@babel/preset-env",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "uuid": "^8.0.0"
   },
   "devDependencies": {
+    "@babel/plugin-transform-react-jsx": "^7.14.5",
     "jest": "^24.9.0",
     "@babel/core": "^7.8.7",
     "@babel/polyfill": "^7.8.7",


### PR DESCRIPTION
`aio app run`, and going to the web-app, does not show the web-app. In the Developer Console of the browser, there is a `React is not defined` error. The fix was listed in the aio-cli-plugin-app@7.0.0 release notes: https://github.com/adobe/aio-cli-plugin-app/releases/tag/7.0.0





